### PR TITLE
Include the source language in code blocks if available.

### DIFF
--- a/src/markdown/BlockParser.hx
+++ b/src/markdown/BlockParser.hx
@@ -379,7 +379,11 @@ class GitHubCodeBlockSyntax extends BlockSyntax
 		var syntax = pattern.matched(1);
 		var childLines = parseChildLines(parser);
 		
-		return new ElementNode('pre', [ElementNode.text('code', childLines.join('\n').htmlEscape())]);
+		var code = ElementNode.text('code', childLines.join('\n').htmlEscape());
+		if (syntax != null && syntax.length > 0) {
+			code.attributes.set('class', 'prettyprint '+syntax);
+		}
+		return new ElementNode('pre', [code]);
 	}
 }
 


### PR DESCRIPTION
Also add the prettyprint class name, for easy integration with
google-code-prettify. I'm using this for syntax highlighted examples on
the Flambe docs: https://aduros.com/flambe/api/flambe/util/Pool.html
