### PR TITLE
Compile fix

### DIFF
--- a/src/markdown/BlockParser.hx
+++ b/src/markdown/BlockParser.hx
@@ -722,14 +722,16 @@ class TableSyntax extends BlockSyntax
 
 		// get alignment from separator line
 		var aligns = [];
-		CELL_PATTERN.map(alignLine, function(e){
-			var text = e.matched(2);
-			var align = text.charAt(0) == ':' 
-				? text.charAt(text.length - 1) == ':' ? 'center' : 'left'
-				: text.charAt(text.length - 1) == ':' ? 'right' : 'left';
-			aligns.push(align);
-			return '';
-		});
+		if (alignLine != null) {
+			CELL_PATTERN.map(alignLine, function(e){
+				var text = e.matched(2);
+				var align = text.charAt(0) == ':' 
+					? text.charAt(text.length - 1) == ':' ? 'center' : 'left'
+					: text.charAt(text.length - 1) == ':' ? 'right' : 'left';
+				aligns.push(align);
+				return '';
+			});
+		}
 		
 		// create thead
 		var index = 0;


### PR DESCRIPTION
This minor change was required (as well as using GIT versions of hxtemplo and dox) in order to run dox against the haxe XML output from OpenFL. BTW, is there a way to filter Haxe standard classes? Thanks!
