### PR TITLE
Fix ATX header trailing # characters

### DIFF
--- a/src/markdown/BlockParser.hx
+++ b/src/markdown/BlockParser.hx
@@ -77,7 +77,7 @@ class BlockSyntax
 	/**
 		Leading (and trailing) `#` define atx-style headers.
 	**/
-	static var RE_HEADER = new EReg('^(#{1,6})(.*?)#*$', '');
+	static var RE_HEADER = new EReg('^(#{1,6})(.*?)( +#* *)?$', '');
 
 	/**
 		The line starts with `>` with one optional space after.


### PR DESCRIPTION
Closes https://github.com/HaxeFoundation/HaxeManual/issues/328.

`# foobar#` should include the `#` in the title. It is only ignored if the trailing `#` characters appear after one or more spaces.