### PR TITLE
handle links with parentheses in them

### DIFF
--- a/src/markdown/InlineParser.hx
+++ b/src/markdown/InlineParser.hx
@@ -363,7 +363,7 @@ class LinkSyntax extends TagSyntax
 	static var linkPattern = '\\](?:('+
 		'\\s?\\[([^\\]]*)\\]'+
 		'|'+
-		'\\s?\\(([^ )]+)(?:[ ]*"([^"]+)"|)\\)'+
+		'\\s?\\((.+?\\)?)(?:[ ]*"([^"]+)"|)\\)'+
 		')|)';
 
 	// The groups matched by this are:
@@ -467,7 +467,7 @@ class ImgSyntax extends TagSyntax
 	static var linkPattern = '\\](?:('+
 		'\\s?\\[([^\\]]*)\\]'+
 		'|'+
-		'\\s?\\(([^ )]+)(?:[ ]*"([^"]+)"|)\\)'+
+		'\\s?\\((.+?\\)?)(?:[ ]*"([^"]+)"|)\\)'+
 		')|)';
 
 	// The groups matched by this are:


### PR DESCRIPTION
I couldn't get tests to run, so only tested on my use case.
I'm also not great at regex, so if someone could sanity-check, I would appreciate it.