### PR TITLE
BlockParser: allow hyphen in fenced code block language name

### DIFF
--- a/src/markdown/BlockParser.hx
+++ b/src/markdown/BlockParser.hx
@@ -95,7 +95,7 @@ class BlockSyntax {
 	/**
 		GitHub style triple quoted code block.
 	**/
-	static var RE_CODE = new EReg('^```(\\w*)\\s*$', '');
+	static var RE_CODE = new EReg('^```([\\w\\-]*)\\s*$', '');
 
 	/**
 		Three or more hyphens, asterisks or underscores by themselves. Note that


### PR DESCRIPTION
I ran into a situation where a programming language name contained a hyphen, like `foo-bar`. Other Markdown parsers allow the `-` character in a fenced code block, but the haxe-markdown parser currently fails to recognize the name because it searches for `[\w]*` only, which doesn't include `-`.

Example:

~~~
```foo-bar
```
~~~