### PR TITLE
BlockParser: update RE_CODE to match CommonMark spec better

### DIFF
--- a/src/markdown/BlockParser.hx
+++ b/src/markdown/BlockParser.hx
@@ -95,7 +95,7 @@ class BlockSyntax {
 	/**
 		GitHub style triple quoted code block.
 	**/
-	static var RE_CODE = new EReg('^```(\\w*)\\s*$', '');
+	static var RE_CODE = new EReg('^```([^`]*)\\s*$', '');
 
 	/**
 		Three or more hyphens, asterisks or underscores by themselves. Note that


### PR DESCRIPTION
The info string following a code fence is allowed to contain any character except backtick (`)

Source: https://spec.commonmark.org/0.30/#fenced-code-blocks

Example that this fixes from the Haxe language server:

``````
```haxe.type
TextField
```
``````